### PR TITLE
Downloader requires Admin or Owner

### DIFF
--- a/cogs/downloader.py
+++ b/cogs/downloader.py
@@ -43,7 +43,7 @@ class Downloader:
         dataIO.save_json(self.file_path, self.repos)
 
     @commands.group(pass_context=True)
-    @checks.is_owner()
+    @checks.admin()
     async def cog(self, ctx):
         """Additional cogs management"""
         if ctx.invoked_subcommand is None:


### PR DESCRIPTION
To better enable me to set up cogs on HTT, I've changed the downloader cog to only require admin privileges.